### PR TITLE
Make i3exit path explicit

### DIFF
--- a/i3/config
+++ b/i3/config
@@ -191,13 +191,13 @@ exec --no-startup-id /usr/bin/xset r rate 200 100
 bindsym $mod+q mode "$mode_system"
 set $mode_system (l)ock, (e)xit, switch_(u)ser, (s)uspend, (h)ibernate, (r)eboot, (Shift+s)hutdown
 mode "$mode_system" {
-    bindsym l exec --no-startup-id i3exit lock, mode "default"
-    bindsym s exec --no-startup-id i3exit suspend, mode "default"
-    bindsym u exec --no-startup-id i3exit switch_user, mode "default"
-    bindsym e exec --no-startup-id i3exit logout, mode "default"
-    bindsym h exec --no-startup-id i3exit hibernate, mode "default"
-    bindsym r exec --no-startup-id i3exit reboot, mode "default"
-    bindsym Shift+s exec --no-startup-id i3exit shutdown, mode "default"
+    bindsym l exec --no-startup-id ~/bin/i3exit lock, mode "default"
+    bindsym s exec --no-startup-id ~/bin/i3exit suspend, mode "default"
+    bindsym u exec --no-startup-id ~/bin/i3exit switch_user, mode "default"
+    bindsym e exec --no-startup-id ~/bin/i3exit logout, mode "default"
+    bindsym h exec --no-startup-id ~/bin/i3exit hibernate, mode "default"
+    bindsym r exec --no-startup-id ~/bin/i3exit reboot, mode "default"
+    bindsym Shift+s exec --no-startup-id ~/bin/i3exit shutdown, mode "default"
 
     ## exit system mode: "Enter" or "Escape"
     bindsym Return mode "default"


### PR DESCRIPTION
Having i3exit in my own path was not enough and I do not think it is
appropriate to maintain this in /usr/bin, so the path configured must be
explicit.